### PR TITLE
rtl8852au: Fix build on 5.19.2 as there is no roam_info.links[0].bssi…

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1164,7 +1164,7 @@ check_bss:
 		#endif
 
 		#if defined(CPTCFG_VERSION) || LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
 		roam_info.bssid = cur_network->network.MacAddress;
 #else
 		roam_info.links[0].bssid = cur_network->network.MacAddress;


### PR DESCRIPTION
You did the same change already in another repository so....