### PR TITLE
Fix `make sign-install` failing because of a typo in .ko name (`8812au.ko` => `8852au.ko`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ uninstall:
 sign:
 	@openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out MOK.der -nodes -days 36500 -subj "/CN=Custom MOK/"
 	@mokutil --import MOK.der
-	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der 8812au.ko
+	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der 8852au.ko
 
 sign-install: all sign install
 


### PR DESCRIPTION
As said in the title. Applying this patch is necessary to do the installation under secure boot.