### PR TITLE
fix issues #52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,9 @@ else
 
 export CONFIG_RTL8852AU = m
 
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
+ARCH ?= $(SUBARCH)
+
 all: modules
 
 modules:

--- a/os_dep/osdep_service_linux.c
+++ b/os_dep/osdep_service_linux.c
@@ -389,6 +389,8 @@ static int openFile(struct file **fpp, const char *path, int flag, int mode)
 {
 	struct file *fp;
 
+	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+
 	fp = filp_open(path, flag, mode);
 	if (IS_ERR(fp)) {
 		*fpp = NULL;
@@ -502,6 +504,8 @@ static int isFileReadable(const char *path, u32 *sz)
 	mm_segment_t oldfs;
 	#endif
 	char buf;
+
+	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
 
 	fp = filp_open(path, O_RDONLY, 0);
 	if (IS_ERR(fp))


### PR DESCRIPTION
fix #52, 
and fix
`ERROR: modpost: module 8852au uses symbol filp_open from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.`