### PR TITLE
Add loongarch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EXTRA_LDFLAGS += --strip-debug
 
 CONFIG_AUTOCFG_CP = n
 
-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/; s/loong.*64/loongarch/;")
 ARCH ?= $(SUBARCH)
 
 ifeq ("","$(wildcard MOK.der)")
@@ -577,7 +577,7 @@ else ifeq ($(CONFIG_SEC_AMSDU_MODE), disable)
 EXTRA_CFLAGS += -DRTW_AMSDU_MODE=2
 endif
 
-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/; s/loong.*64/loongarch/;")
 ARCH ?= $(SUBARCH)
 
 ########### PLATFORM OPS  ##########################
@@ -629,7 +629,7 @@ else
 
 export CONFIG_RTL8852AU = m
 
-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/; s/loong.*64/loongarch/;")
 ARCH ?= $(SUBARCH)
 
 all: modules


### PR DESCRIPTION
Add loongarch support.

# Test environment #

* CPU: Loongson LS3A6000 (Not announced yet)
* OS: [fedora remix loongarch](https://github.com/fedora-remix-loongarch/releases-info)
* linux kernel: [6.6.2](https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.2.tar.xz)
* linux-firmware: [20231111-1.fc38](https://koji.fedoraproject.org/koji/buildinfo?buildID=2320729)

## Part of `modinfo 8852au` output ##

    # modinfo 8852au                                                                                                                                               
    filename:       /lib/modules/6.6.2-1.loongarch64/kernel/drivers/net/wireless/realtek/rtw89/8852au.ko                                                           
    ....
    vermagic:       6.6.2-1.loongarch64 SMP preempt mod_unload modversions LOONGARCH 64BIT 
    ....

----
<del>
# Note #
The linux-firmware package in [fedora remix loongarch](https://github.com/fedora-remix-loongarch/releases-info) is too old, it must be upgraded to new version (see the linux-firmware link above), otherwise, `lsusb` will show something like `Bus 002 Device 004: ID 0bda:1a2b Realtek Semiconductor Corp. RTL8188GU 802.11n WLAN Adapter (Driver CDROM Mode)`, and the USB WiFi device will be a hard disk drive (`/dev/sdX`) with Windows driver in it.
</del>

**See lwfinger's comments below.**