### PR TITLE
rtl8852au: Fix builds for kernel 6.8

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -482,13 +482,28 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
 
 	wdev = dev->ieee80211_ptr;
 	if (wdev) {
-		strlcpy(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+		strscpy
+#else
+		strlcpy
+#endif
+			(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
 			sizeof(info->driver));
 	} else {
-		strlcpy(info->driver, "N/A", sizeof(info->driver));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+		strscpy
+#else
+		strlcpy
+#endif
+			(info->driver, "N/A", sizeof(info->driver));
 	}
 
-	strlcpy(info->version, DRIVERVERSION, sizeof(info->version));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+	strscpy
+#else
+	strlcpy
+#endif
+		(info->version, DRIVERVERSION, sizeof(info->version));
 
 	padapter = (_adapter *)rtw_netdev_priv(dev);
 
@@ -505,10 +520,20 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
 	} else
 	#endif
 	{
-		strlcpy(info->fw_version, "N/A", sizeof(info->fw_version));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+		strscpy
+#else
+		strlcpy
+#endif
+			(info->fw_version, "N/A", sizeof(info->fw_version));
 	}
 
-	strlcpy(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+	strscpy
+#else
+	strlcpy
+#endif
+		(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
 		sizeof(info->bus_info));
 }
 

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -218,7 +218,7 @@ struct rtw_usb_drv usb_drv = {
 	.usbdrv.reset_resume   = rtw_dev_resume,
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0))
 	.usbdrv.drvwrap.driver.shutdown = rtw_dev_shutdown,
 #else
 	.usbdrv.driver.shutdown = rtw_dev_shutdown,


### PR DESCRIPTION
# References #

* [Merge tag 'strlcpy-removal-v6.8-rc1' of git://git.kernel.org/pub/scm/linux/kernel/git/kees/linux](https://github.com/torvalds/linux/commit/57f22c8dab6b266ae36b89b073a4a33dea71e762)
* [USB: core: Use device_driver directly in struct usb_driver and usb_device_driver](https://github.com/torvalds/linux/commit/49a78b05d5ca1e23fd737747a8757b8bdc319b30)