### PR TITLE
fix: fallthrough compile error

### DIFF
--- a/include/drv_conf.h
+++ b/include/drv_conf.h
@@ -51,7 +51,7 @@
 #endif
 
 #if !defined(fallthrough)
-#define fallthrough (do {} while(0))
+#define fallthrough __attribute__((fallthrough))
 #endif
 
 #ifdef CONFIG_RTW_ANDROID


### PR DESCRIPTION
The original fallthrough macro definition caused a compile error due to its incompatible syntax in certain compiler versions. 

![image](https://github.com/lwfinger/rtl8852au/assets/48535768/60b32957-566c-4511-b699-aec3c8cfccd3)


This commit replaces the fallthrough macro definition with the __attribute__((fallthrough)) syntax, which is recognized by GCC and resolves the compilation issue. 

This change ensures compatibility and prevents the "expected expression before ‘do’" error during the build process.

![image](https://github.com/lwfinger/rtl8852au/assets/48535768/aa024557-668b-44be-b86f-205b4324fc89)
