### PR TITLE
Replace suspend_rtw8852au to eliminate bashisms

### DIFF
--- a/suspend_rtw8852au
+++ b/suspend_rtw8852au
@@ -6,13 +6,10 @@
 case $1 in
   pre)
   # Shutdown
-    echo "we are suspending at $(date)..." >> /tmp/systemd_suspend_test
     modprobe -rv 8852au
     ;;
   post)
   # Resume
-    echo "...and we are back from $(date)" >> /tmp/systemd_suspend_test
-    #sleep 15
     modprobe -v 8852au
     ;;
 esac

--- a/suspend_rtw8852au
+++ b/suspend_rtw8852au
@@ -3,10 +3,16 @@
 # Script to unload 8852au before suspend or hibernate, and restore on resume
 # Save in /usr/lib/systemd/system-sleep/
 #
-if [ "${1}" == "pre" ]; then
-# Shutdown
-  modprobe -rv 8852au
-elif [ "${1}" == "post" ]; then
-# Resume
-  modprobe -v 8852au
-fi
+case $1 in
+  pre)
+  # Shutdown
+    echo "we are suspending at $(date)..." >> /tmp/systemd_suspend_test
+    modprobe -rv 8852au
+    ;;
+  post)
+  # Resume
+    echo "...and we are back from $(date)" >> /tmp/systemd_suspend_test
+    #sleep 15
+    modprobe -v 8852au
+    ;;
+esac


### PR DESCRIPTION
The original version of suspend_rtw8852au uses bashisms such as ==.  This fails with non-bash shells, such as dash, which is standard on Ubuntu, resulting in ``unknown operator "pre" '' messages in logs.
