### PR TITLE
Update README.md to point to rtl8852au

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ sudo zypper install make gcc kernel-devel kernel-default-devel git libopenssl-de
 ```
 For **Arch**: After installing the necessary kernel headers and base-devel,
 ```bash
-git clone https://aur.archlinux.org/rtw89-dkms-git.git
-cd rtw89-dkms-git
+git clone https://aur.archlinux.org/rtl8852au-dkms-git.git
+cd rtl8852au-dkms-git
 makepkg -sri
 ```
 If any of the packages above are not found check if your distro installs them like that.


### PR DESCRIPTION
The git clone instructions for archlinux aur were incorrect for this repo. rtw89 should be rtl8852au