### PR TITLE
Add device 3625:010f

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -165,6 +165,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(0x35bc, 0x0100, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x013f, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0140, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
+  {USB_DEVICE_AND_INTERFACE_INFO(0x3625, 0x010f, 0xff, 0xff, 0xff), .driver_info = RTL8852A},
 
 	/*=== TP-Link Archer TX20UH ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_TPLINK, 0x0141, 0xff, 0xff, 0xff), .driver_info = RTL8852A},


### PR DESCRIPTION
## Changes

- Add 3625:010f Realteck 802.11ac WLAN Adapter

## Details

Product name : TPLink Archer TX35U Plus

- https://www.tp-link.com/en/home-networking/high-gain-adapter/archer-tx35u-plus/

```bash
~ $ lsusb
...
Bus 001 Device 009: ID 3625:010f Realtek 802.11ac WLAN Adapter
...
```

## Verification

### Environment

- Machine : Raspberry Pi 400 (aarch64)
- OS
```bash
~ $ lsb_release - a
Distributor ID:	Debian
Description:	Debian GNU/Linux 13 (trixie)
Release:	13
Codename:	trixie
```
- Kernel
```bash
~ $ uname -r
6.12.62+rpt-rpi-v8
```

### Installation Command

- [x] manual installation
```bash
~ $ git clone {repo} && cd {path}
~ $ make
~ $ sudo mkdir -p /usr/lib/systemd/system-sleep #raspberry pi does not have the path
~ $ sudo make install
~ $ sudo modprobe -r 8852au && sudo modprobe 8852au
```

- [x] dkms installation
```bash
~ $ git clone {repo} && cd {path}
~ $ sudo dkms add .
~ $ sudo dkms build rtl8852au -v 1.15.0.1
~ $ sudo dkms install rtl8852au -v 1.15.0.1
~ $ modinfo 8852au
~ $ modprobe 8852au
~ $ depmod -a
```

### Verification Command

```bash
~ $ lsmod | grep 8852au
8852au              13328384  0
...
~ $ ifconfig
wlan1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
...
~ $ udevadm info /sys/class/net/wlan1
...
E: SUBSYSTEM=net
E: DEVTYPE=wlan
...
E: ID_NET_DRIVER=rtl8852au
E: ID_BUS=usb
E: ID_MODEL=802.11ac_WLAN_Adapter
E: ID_MODEL_ENC=802.11ac\x20WLAN\x20Adapter
E: ID_MODEL_ID=010f
E: ID_SERIAL=Realtek_802.11ac_WLAN_Adapter_00e04c000001
E: ID_SERIAL_SHORT=00e04c000001
E: ID_VENDOR=Realtek
E: ID_VENDOR_ENC=Realtek
E: ID_VENDOR_ID=3625
E: ID_REVISION=0000
...
```